### PR TITLE
[FIX] Handle validators in arrays with simple values

### DIFF
--- a/jcv-core/src/main/java/com/ekino/oss/jcv/core/JsonComparator.java
+++ b/jcv-core/src/main/java/com/ekino/oss/jcv/core/JsonComparator.java
@@ -3,14 +3,21 @@
  */
 package com.ekino.oss.jcv.core;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import com.ekino.oss.jcv.core.validator.ValidatorTemplateManager;
 import org.json.JSONArray;
@@ -24,6 +31,7 @@ import org.skyscreamer.jsonassert.ValueMatcherException;
 import org.skyscreamer.jsonassert.comparator.DefaultComparator;
 import org.skyscreamer.jsonassert.comparator.JSONComparator;
 
+import static java.util.stream.Collectors.*;
 import static org.skyscreamer.jsonassert.comparator.JSONCompareUtil.*;
 
 /**
@@ -138,5 +146,198 @@ public class JsonComparator extends DefaultComparator {
             }
         }
         return true;
+    }
+
+    @Override
+    protected void compareJSONArrayOfSimpleValues(String key, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
+        List<Object> expectedElements = jsonArrayToList(expected);
+        List<Object> actualElements = jsonArrayToList(actual);
+
+        List<ExpectedElement> parsedExpectedElements = parseExpectedElements(key, expectedElements);
+
+        if (parsedExpectedElements.stream().noneMatch(ExpectedElement::hasCustomization)) {
+            super.compareJSONArrayOfSimpleValues(key, expected, actual, result);
+            return;
+        }
+
+        Set<Integer> actualValueMatchedIndexes = new HashSet<>();
+        Map<ExpectedElement, Optional<ActualElement>> matchingByValue = getMatchingByValue(parsedExpectedElements, actualElements, actualValueMatchedIndexes);
+        Map<ExpectedElement, Collection<ActualElement>> matchingByValidator = getExpectedElementCollectionMap(parsedExpectedElements, key, actualElements, actualValueMatchedIndexes);
+
+        long totalMatched = matchingByValue.values().stream().filter(Optional::isPresent).count()
+            + matchingByValidator.values().stream().flatMap(Collection::stream).distinct().count();
+
+        if (totalMatched != actualElements.size()) {
+
+            Map<ExpectedElement, Collection<ActualElement>> allMatches = Stream.concat(
+                matchingByValue.entrySet().stream()
+                    .map(entry -> new AbstractMap.SimpleEntry<ExpectedElement, Collection<ActualElement>>(entry.getKey(), entry.getValue().map(Collections::singletonList).orElseGet(Collections::emptyList)))
+                    .map(it -> (Map.Entry<ExpectedElement, Collection<ActualElement>>) it),
+                matchingByValidator.entrySet().stream()
+            )
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            Set<Integer> allMatchedActualIndexes = allMatches.values().stream()
+                .flatMap(Collection::stream)
+                .map(ActualElement::getIndex)
+                .collect(toSet());
+
+            IntStream.range(0, actualElements.size())
+                .filter(it -> !allMatchedActualIndexes.contains(it))
+                .forEachOrdered(actualIndex -> result.unexpected(key + "[" + actualIndex + "]", actualElements.get(actualIndex)));
+
+            String detailedMatchingDebugMessage = allMatches
+                .entrySet()
+                .stream()
+                .sorted(Comparator.comparing(entry -> entry.getKey().getIndex()))
+                .map(entry -> {
+                    ExpectedElement expectedElt = entry.getKey();
+                    String matchedElements = entry.getValue().stream()
+                        .map(it -> "[" + it.getIndex() + "] -> " + it.getValue())
+                        .collect(joining(",", "[", "]"));
+                    return key + "[" + expectedElt.getIndex() + "] -> " + expectedElt.getKey() + " matched with: " + matchedElements;
+                })
+                .collect(joining("\n"));
+            result.fail(detailedMatchingDebugMessage);
+        }
+    }
+
+    private List<ExpectedElement> parseExpectedElements(String key, List<Object> expectedElements) {
+        List<ExpectedElement> parsedExpectedElements = new ArrayList<>();
+        for (int i = 0; i < expectedElements.size(); i++) {
+            Object expectedElement = expectedElements.get(i);
+            parsedExpectedElements.add(new ExpectedElement(
+                i,
+                expectedElement,
+                validators.stream()
+                    .filter(it -> it.getContextMatcher().matches(key, expectedElement, null))
+                    .findFirst()
+                    .map(toMatcher())
+                    .map(it -> new Customization(IGNORED_PATH, it))
+                    .orElse(null)
+            ));
+        }
+        return parsedExpectedElements;
+    }
+
+    private Map<ExpectedElement, Optional<ActualElement>> getMatchingByValue(List<ExpectedElement> parsedExpectedElements,
+                                                                             List<Object> actualElements,
+                                                                             Set<Integer> actualValueMatchedIndexes) {
+        return parsedExpectedElements.stream()
+            .filter(it -> !it.hasCustomization())
+            .map(expectedElement -> {
+                for (int i = 0; i < actualElements.size(); i++) {
+                    if (actualValueMatchedIndexes.contains(i)) {
+                        continue;
+                    }
+                    Object actualElement = actualElements.get(i);
+                    if (expectedElement.getKey().equals(actualElement)) {
+                        actualValueMatchedIndexes.add(i);
+                        return new AbstractMap.SimpleEntry<>(expectedElement, Optional.of(new ActualElement(i, actualElement)));
+                    }
+                }
+                return new AbstractMap.SimpleEntry<>(expectedElement, Optional.<ActualElement>empty());
+            })
+            .collect(toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+    }
+
+    private Map<ExpectedElement, Collection<ActualElement>> getExpectedElementCollectionMap(List<ExpectedElement> parsedExpectedElements,
+                                                                                            String key,
+                                                                                            List<Object> actualElements,
+                                                                                            Set<Integer> actualValueMatchedIndexes) {
+        return parsedExpectedElements.stream()
+            .filter(ExpectedElement::hasCustomization)
+            .map(expectedElement -> {
+                Set<ActualElement> matched = new HashSet<>();
+                for (int i = 0; i < actualElements.size(); i++) {
+                    if (actualValueMatchedIndexes.contains(i)) {
+                        continue;
+                    }
+                    Object actualElement = actualElements.get(i);
+                    try {
+                        if (expectedElement.getCustomization().matches(key, actualElement, expectedElement.getKey(), new JSONCompareResult())) {
+                            matched.add(new ActualElement(i, actualElement));
+                        }
+                    } catch (ValueMatcherException e) {
+                        // Do nothing
+                    }
+                }
+                return new AbstractMap.SimpleEntry<>(expectedElement, matched);
+            })
+            .collect(toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+    }
+
+    private static class ExpectedElement {
+        private final Integer index;
+        private final Object key;
+        private final Customization customization;
+
+        private ExpectedElement(Integer index, Object key, Customization customization) {
+            this.index = index;
+            this.key = key;
+            this.customization = customization;
+        }
+
+        Integer getIndex() {
+            return index;
+        }
+
+        Object getKey() {
+            return key;
+        }
+
+        Customization getCustomization() {
+            return customization;
+        }
+
+        boolean hasCustomization() {
+            return customization != null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ExpectedElement that = (ExpectedElement) o;
+            return Objects.equals(index, that.index) &&
+                Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(index, key);
+        }
+    }
+
+    private static class ActualElement {
+        private final Integer index;
+        private final Object value;
+
+        ActualElement(Integer index, Object value) {
+            this.index = index;
+            this.value = value;
+        }
+
+        Integer getIndex() {
+            return index;
+        }
+
+        Object getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ActualElement that = (ActualElement) o;
+            return Objects.equals(index, that.index) &&
+                Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(index, value);
+        }
     }
 }

--- a/jcv-core/src/test/resources/array_with_simple_values/test_actual.json
+++ b/jcv-core/src/test/resources/array_with_simple_values/test_actual.json
@@ -1,0 +1,14 @@
+{
+  "array_1": [
+    "value_1",
+    "value_2",
+    "value_3"
+  ],
+  "array_2": [
+    "cd820a36-aa32-42ea-879d-293ba5f3c1e5",
+    "value_1",
+    "hello",
+    "value_3",
+    "839ceac0-2e60-4405-b27c-db2ac753d809"
+  ]
+}

--- a/jcv-core/src/test/resources/array_with_simple_values/test_expected.json
+++ b/jcv-core/src/test/resources/array_with_simple_values/test_expected.json
@@ -1,0 +1,14 @@
+{
+  "array_1": [
+    "value_3",
+    "value_1",
+    "value_2"
+  ],
+  "array_2": [
+    "value_1",
+    "{#uuid#}",
+    "{#uuid#}",
+    "{#starts_with:hel#}",
+    "{#contains:value_#}"
+  ]
+}


### PR DESCRIPTION
Make validators available in assertions of arrays with simple values.