### PR TITLE
feat(check commit): add pre-commit and hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ gradle-app.setting
 
 # Gradle changelog plugin
 .okhttpcache/
+
+#node
+/node_modules
+package-lock.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,29 @@
 import net.researchgate.release.ReleasePlugin
 import se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask
+import com.moowork.gradle.node.NodePlugin
+import com.moowork.gradle.node.NodeExtension
+
 
 plugins {
     base
     kotlin("jvm") version "1.3.50" apply false
     id("net.researchgate.release") version "2.8.1"
     id("se.bjurr.gitchangelog.git-changelog-gradle-plugin") version "1.64"
+    id("com.github.node-gradle.node") version "2.2.0"
 }
+
+apply<NodePlugin>()
+
+configure<NodeExtension> {
+    version = "12.13.1"
+    download = true
+    workDir = file("${project.buildDir}/.nodejs")
+}
+
+tasks.named("build") {
+    dependsOn(":npmInstall")
+}
+
 
 allprojects {
     group = "com.ekino.oss.jcv"
@@ -95,3 +112,4 @@ subprojects {
         }
     }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "jcv",
+  "version": "1.0.0",
+  "description": "JSON Content Validator (JCV) allows you to compare JSON contents with embedded validation.",
+  "main": "index.js",
+  "devDependencies": {
+    "husky": "^3.1.0",
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ekino/jcv.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ekino/jcv/issues"
+  },
+  "homepage": "https://github.com/ekino/jcv#readme"
+}


### PR DESCRIPTION
Use npm to have a feature of git hook checking for conventional commits.
Pro : a ready-to-use solution
Cons : introduce package.json in the project 
But with this kind of solution we can have the same requirement on commits for front and back projects ...
Maybe will it be interesting to add this kind of feature in our gradle-quality-plugin ...?
